### PR TITLE
feat: add app.setup.configOverridden event when config is overridden

### DIFF
--- a/lib/spawnpoint.js
+++ b/lib/spawnpoint.js
@@ -795,6 +795,8 @@ class spawnpoint extends EventEmitter {
 			if(access) {
 				this.debug('Overriding config with custom overrides');
 				_.each(access, (value, key) => this.registerConfig(key, value, 'config-hoist'));
+				// Emit an event to allow plugins to know that the config has been overridden
+				this.emit('app.setup.configOverridden');
 			}
 		}
 		return this;


### PR DESCRIPTION
This fires a new event called `app.setup.configOverridden` when a config override is set and successfully overrides any values. This then can be used by the app however wanted. 